### PR TITLE
Add ms-viewport to responsive.less

### DIFF
--- a/5kaday/less/responsive.less
+++ b/5kaday/less/responsive.less
@@ -302,3 +302,9 @@
 
 }
 
+/* This fixes the Mobile IE10 issue on WP8 devices running Update 3 or higher 
+    Phones running GDR2 or lower will have to (dealwithit)
+*/
+@-ms-viewport {
+	width: device-width;
+}


### PR DESCRIPTION
According to the October 15th update on this page (http://mattstow.com/responsive-design-in-ie10-on-windows-phone-8.html), this fix should work in Mobile IE10 on WP8s using GDR3. I have a preview of the update on my phone and it looks like phones are starting to get the full release now-ish as well.

I haven't had a chance to test this but figured this shouldn't hurt anything if it doesn't work and we can take a look at it some more later.
